### PR TITLE
Bump the play.http.parser.maxMemoryBuffer

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -185,3 +185,5 @@ tracking-consent-frontend {
 dependent-tasks = [
   ".preTaskList"
 ]
+
+play.http.parser.maxMemoryBuffer=15M


### PR DESCRIPTION
Bump the play.http.parser.maxMemoryBuffer property to 15mb to cater for large volumes returned in reference data calls