### PR TITLE
CTCP-4313: Handling a NotFoundException in certain cases.

### DIFF
--- a/app/connectors/ReferenceDataConnector.scala
+++ b/app/connectors/ReferenceDataConnector.scala
@@ -20,10 +20,10 @@ import config.FrontendAppConfig
 import models.reference._
 import models.{LocationOfGoodsIdentification, LocationType}
 import play.api.Logging
-import play.api.http.Status.{NOT_FOUND, NO_CONTENT, OK}
-import play.api.libs.json.Reads
+import play.api.http.Status.OK
+import play.api.libs.json.{JsError, JsResultException, JsSuccess, Reads}
 import sttp.model.HeaderNames
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, HttpResponse}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, HttpResponse, NotFoundException}
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
@@ -120,19 +120,17 @@ class ReferenceDataConnector @Inject() (config: FrontendAppConfig, http: HttpCli
     (_: String, _: String, response: HttpResponse) => {
       response.status match {
         case OK =>
-          (response.json \ "data")
-            .validate[Seq[A]]
-            .getOrElse(
-              throw new IllegalStateException("[ReferenceDataConnector][responseHandlerGeneric] Reference data could not be parsed")
-            )
-        case NO_CONTENT =>
-          Nil
-        case NOT_FOUND =>
-          logger.warn("[ReferenceDataConnector][responseHandlerGeneric] Reference data call returned NOT_FOUND")
-          throw new IllegalStateException("[ReferenceDataConnector][responseHandlerGeneric] Reference data could not be found")
-        case other =>
-          logger.warn(s"[ReferenceDataConnector][responseHandlerGeneric] Invalid downstream status $other")
-          throw new IllegalStateException(s"[ReferenceDataConnector][responseHandlerGeneric] Invalid Downstream Status $other")
+          (response.json \ "data").validate[Seq[A]] match {
+            case JsSuccess(Nil, _) =>
+              throw new NotFoundException(s"[ReferenceDataConnector][responseHandlerGeneric] No reference data found.")
+            case JsSuccess(value, _) =>
+              value
+            case JsError(errors) =>
+              throw JsResultException(errors)
+          }
+        case e =>
+          logger.warn(s"[ReferenceDataConnector][responseHandlerGeneric] Reference data call returned $e")
+          throw new Exception(s"[ReferenceDataConnector][responseHandlerGeneric] $e - ${response.body}")
       }
     }
 }

--- a/app/connectors/ReferenceDataConnector.scala
+++ b/app/connectors/ReferenceDataConnector.scala
@@ -17,13 +17,14 @@
 package connectors
 
 import config.FrontendAppConfig
+import connectors.ReferenceDataConnector.NoReferenceDataFoundException
 import models.reference._
 import models.{LocationOfGoodsIdentification, LocationType}
 import play.api.Logging
 import play.api.http.Status.OK
 import play.api.libs.json.{JsError, JsResultException, JsSuccess, Reads}
 import sttp.model.HeaderNames
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, HttpResponse, NotFoundException}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, HttpResponse}
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
@@ -122,7 +123,7 @@ class ReferenceDataConnector @Inject() (config: FrontendAppConfig, http: HttpCli
         case OK =>
           (response.json \ "data").validate[Seq[A]] match {
             case JsSuccess(Nil, _) =>
-              throw new NotFoundException(s"[ReferenceDataConnector][responseHandlerGeneric] No reference data found.")
+              throw new NoReferenceDataFoundException
             case JsSuccess(value, _) =>
               value
             case JsError(errors) =>
@@ -133,4 +134,9 @@ class ReferenceDataConnector @Inject() (config: FrontendAppConfig, http: HttpCli
           throw new Exception(s"[ReferenceDataConnector][responseHandlerGeneric] $e - ${response.body}")
       }
     }
+}
+
+object ReferenceDataConnector {
+
+  class NoReferenceDataFoundException extends Exception("The reference data call was successful but the response body is empty.")
 }

--- a/app/controllers/exit/index/OfficeOfExitCountryController.scala
+++ b/app/controllers/exit/index/OfficeOfExitCountryController.scala
@@ -17,6 +17,7 @@
 package controllers.exit.index
 
 import config.PhaseConfig
+import connectors.ReferenceDataConnector.NoReferenceDataFoundException
 import controllers.actions._
 import controllers.{NavigatorOps, SettableOps, SettableOpsRunner}
 import forms.SelectableFormProvider
@@ -32,7 +33,6 @@ import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import repositories.SessionRepository
 import services.{CountriesService, CustomsOfficesService}
-import uk.gov.hmrc.http.NotFoundException
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.exit.index.OfficeOfExitCountryView
 
@@ -96,7 +96,7 @@ class OfficeOfExitCountryController @Inject() (
                       _ => redirect(mode, index, OfficeOfExitCountryPage, value)
                     }
                     .recover {
-                      case _: NotFoundException =>
+                      case _: NoReferenceDataFoundException =>
                         val formWithErrors = form.withError(FormError("value", s"$prefix.error.noOffices"))
                         BadRequest(view(formWithErrors, lrn, countryList.values, index, mode))
                     }

--- a/app/controllers/exit/index/OfficeOfExitCountryController.scala
+++ b/app/controllers/exit/index/OfficeOfExitCountryController.scala
@@ -93,8 +93,7 @@ class OfficeOfExitCountryController @Inject() (
                   customsOfficesService
                     .getCustomsOfficesOfExitForCountry(value.code)
                     .flatMap {
-                      _ =>
-                        redirect(mode, index, OfficeOfExitCountryPage, value)
+                      _ => redirect(mode, index, OfficeOfExitCountryPage, value)
                     }
                     .recover {
                       case _: NotFoundException =>

--- a/app/controllers/routing/CountryOfDestinationController.scala
+++ b/app/controllers/routing/CountryOfDestinationController.scala
@@ -17,6 +17,7 @@
 package controllers.routing
 
 import config.PhaseConfig
+import connectors.ReferenceDataConnector.NoReferenceDataFoundException
 import controllers.actions._
 import controllers.{NavigatorOps, SettableOps, SettableOpsRunner}
 import forms.SelectableFormProvider
@@ -28,7 +29,6 @@ import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import services.{CountriesService, CustomsOfficesService}
-import uk.gov.hmrc.http.NotFoundException
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.routing.CountryOfDestinationView
 
@@ -87,7 +87,7 @@ class CountryOfDestinationController @Inject() (
                         .navigate()
                   }
                   .recover {
-                    case _: NotFoundException =>
+                    case _: NoReferenceDataFoundException =>
                       val formWithErrors = form.withError(FormError("value", s"$prefix.error.noOffices"))
                       BadRequest(view(formWithErrors, lrn, countryList.values, mode))
                   }

--- a/app/controllers/transit/index/OfficeOfTransitCountryController.scala
+++ b/app/controllers/transit/index/OfficeOfTransitCountryController.scala
@@ -17,6 +17,7 @@
 package controllers.transit.index
 
 import config.PhaseConfig
+import connectors.ReferenceDataConnector.NoReferenceDataFoundException
 import controllers.actions._
 import controllers.{NavigatorOps, SettableOps, SettableOpsRunner}
 import forms.SelectableFormProvider
@@ -31,7 +32,6 @@ import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import repositories.SessionRepository
 import services.{CountriesService, CustomsOfficesService}
-import uk.gov.hmrc.http.NotFoundException
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.transit.index.OfficeOfTransitCountryView
 
@@ -86,7 +86,7 @@ class OfficeOfTransitCountryController @Inject() (
                     _ => redirect(mode, index, OfficeOfTransitCountryPage, value)
                   }
                   .recover {
-                    case _: NotFoundException =>
+                    case _: NoReferenceDataFoundException =>
                       val formWithErrors = form.withError(FormError("value", s"$prefix.error.noOffices"))
                       BadRequest(view(formWithErrors, lrn, countryList.values, mode, index))
                   }

--- a/test/connectors/ReferenceDataConnectorSpec.scala
+++ b/test/connectors/ReferenceDataConnectorSpec.scala
@@ -19,13 +19,13 @@ package connectors
 import base.{AppWithDefaultMockFixtures, SpecBase, WireMockServerHandler}
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.matching.StringValuePattern
+import connectors.ReferenceDataConnector.NoReferenceDataFoundException
 import models.LocationType
 import models.reference._
 import org.scalacheck.Gen
 import org.scalatest.Assertion
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.inject.guice.GuiceApplicationBuilder
-import uk.gov.hmrc.http.NotFoundException
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -223,14 +223,14 @@ class ReferenceDataConnectorSpec extends SpecBase with AppWithDefaultMockFixture
         connector.getTypesOfLocation().futureValue mustEqual expectedResult
       }
 
-      "should throw a NotFoundException for an empty list of location types" in {
+      "should throw a NoReferenceDataFoundException for an empty list of location types" in {
         server.stubFor(
           get(urlEqualTo(url))
             .willReturn(okJson(emptyResponseJson))
         )
 
         whenReady[Throwable, Assertion](connector.getTypesOfLocation().failed) {
-          _ mustBe a[NotFoundException]
+          _ mustBe a[NoReferenceDataFoundException]
         }
       }
 
@@ -258,7 +258,7 @@ class ReferenceDataConnectorSpec extends SpecBase with AppWithDefaultMockFixture
         connector.getCustomsOfficesOfTransitForCountry(CountryCode(countryId)).futureValue mustBe expectedResult
       }
 
-      "should throw a NotFoundException for an empty list of customs offices" in {
+      "should throw a NoReferenceDataFoundException for an empty list of customs offices" in {
         val countryId = "AR"
 
         server.stubFor(
@@ -267,7 +267,7 @@ class ReferenceDataConnectorSpec extends SpecBase with AppWithDefaultMockFixture
         )
 
         whenReady[Throwable, Assertion](connector.getCustomsOfficesOfTransitForCountry(CountryCode(countryId)).failed) {
-          _ mustBe a[NotFoundException]
+          _ mustBe a[NoReferenceDataFoundException]
         }
       }
 
@@ -296,7 +296,7 @@ class ReferenceDataConnectorSpec extends SpecBase with AppWithDefaultMockFixture
         connector.getCustomsOfficesOfDestinationForCountry(CountryCode(countryId)).futureValue mustBe expectedResult
       }
 
-      "should throw a NotFoundException for an empty list of customs offices" in {
+      "should throw a NoReferenceDataFoundException for an empty list of customs offices" in {
         val countryId = "AR"
 
         server.stubFor(
@@ -305,7 +305,7 @@ class ReferenceDataConnectorSpec extends SpecBase with AppWithDefaultMockFixture
         )
 
         whenReady[Throwable, Assertion](connector.getCustomsOfficesOfDestinationForCountry(CountryCode(countryId)).failed) {
-          _ mustBe a[NotFoundException]
+          _ mustBe a[NoReferenceDataFoundException]
         }
       }
 
@@ -334,7 +334,7 @@ class ReferenceDataConnectorSpec extends SpecBase with AppWithDefaultMockFixture
         connector.getCustomsOfficesOfExitForCountry(CountryCode(countryId)).futureValue mustBe expectedResult
       }
 
-      "should throw a NotFoundException for an empty list of customs offices" in {
+      "should throw a NoReferenceDataFoundException for an empty list of customs offices" in {
         val countryId = "AR"
 
         server.stubFor(
@@ -343,7 +343,7 @@ class ReferenceDataConnectorSpec extends SpecBase with AppWithDefaultMockFixture
         )
 
         whenReady[Throwable, Assertion](connector.getCustomsOfficesOfExitForCountry(CountryCode(countryId)).failed) {
-          _ mustBe a[NotFoundException]
+          _ mustBe a[NoReferenceDataFoundException]
         }
       }
 
@@ -372,7 +372,7 @@ class ReferenceDataConnectorSpec extends SpecBase with AppWithDefaultMockFixture
         connector.getCustomsOfficesOfDepartureForCountry(countryId).futureValue mustBe expectedResult
       }
 
-      "should throw a NotFoundException for an empty list of customs offices" in {
+      "should throw a NoReferenceDataFoundException for an empty list of customs offices" in {
         val countryId = "AR"
 
         server.stubFor(
@@ -381,7 +381,7 @@ class ReferenceDataConnectorSpec extends SpecBase with AppWithDefaultMockFixture
         )
 
         whenReady[Throwable, Assertion](connector.getCustomsOfficesOfDepartureForCountry(countryId).failed) {
-          _ mustBe a[NotFoundException]
+          _ mustBe a[NoReferenceDataFoundException]
         }
       }
 

--- a/test/connectors/ReferenceDataConnectorSpec.scala
+++ b/test/connectors/ReferenceDataConnectorSpec.scala
@@ -25,9 +25,7 @@ import org.scalacheck.Gen
 import org.scalatest.Assertion
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.mvc.Http.HeaderNames.CONTENT_TYPE
-import play.mvc.Http.MimeTypes.JSON
-import play.mvc.Http.Status._
+import uk.gov.hmrc.http.NotFoundException
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -181,19 +179,25 @@ class ReferenceDataConnectorSpec extends SpecBase with AppWithDefaultMockFixture
 
   private val locationTypesResponseJson: String =
     """
-      |
-      |   {
-      |   "data": [
-      |              {
-      |                "type": "A",
-      |                "description": "Designated location"
-      |              },
-      |              {
-      |                "type": "B",
-      |                "description": "Authorised place"
-      |               }
-      |            ]
-      |   }
+      |{
+      |  "data": [
+      |    {
+      |      "type": "A",
+      |      "description": "Designated location"
+      |    },
+      |    {
+      |      "type": "B",
+      |      "description": "Authorised place"
+      |    }
+      |  ]
+      |}
+      |""".stripMargin
+
+  private val emptyResponseJson: String =
+    """
+      |{
+      |  "data": []
+      |}
       |""".stripMargin
 
   def queryParams(role: String): Seq[(String, StringValuePattern)] = Seq(
@@ -219,13 +223,15 @@ class ReferenceDataConnectorSpec extends SpecBase with AppWithDefaultMockFixture
         connector.getTypesOfLocation().futureValue mustEqual expectedResult
       }
 
-      "should handle a 204 response for location types" in {
+      "should throw a NotFoundException for an empty list of location types" in {
         server.stubFor(
           get(urlEqualTo(url))
-            .willReturn(aResponse().withStatus(NO_CONTENT))
+            .willReturn(okJson(emptyResponseJson))
         )
 
-        connector.getTypesOfLocation().futureValue mustBe Nil
+        whenReady[Throwable, Assertion](connector.getTypesOfLocation().failed) {
+          _ mustBe a[NotFoundException]
+        }
       }
 
       "should handle client and server errors for control types" in {
@@ -252,20 +258,17 @@ class ReferenceDataConnectorSpec extends SpecBase with AppWithDefaultMockFixture
         connector.getCustomsOfficesOfTransitForCountry(CountryCode(countryId)).futureValue mustBe expectedResult
       }
 
-      "must return a successful future response when CustomsOffice returns no data" in {
+      "should throw a NotFoundException for an empty list of customs offices" in {
         val countryId = "AR"
 
         server.stubFor(
-          get(urlEqualTo(url(countryId))).willReturn(
-            aResponse()
-              .withStatus(NO_CONTENT)
-              .withHeader(CONTENT_TYPE, JSON)
-          )
+          get(urlEqualTo(url(countryId)))
+            .willReturn(okJson(emptyResponseJson))
         )
 
-        val expectedResult = Nil
-
-        connector.getCustomsOfficesOfTransitForCountry(CountryCode(countryId)).futureValue mustBe expectedResult
+        whenReady[Throwable, Assertion](connector.getCustomsOfficesOfTransitForCountry(CountryCode(countryId)).failed) {
+          _ mustBe a[NotFoundException]
+        }
       }
 
       "must return an exception when an error response is returned" in {
@@ -293,20 +296,17 @@ class ReferenceDataConnectorSpec extends SpecBase with AppWithDefaultMockFixture
         connector.getCustomsOfficesOfDestinationForCountry(CountryCode(countryId)).futureValue mustBe expectedResult
       }
 
-      "must return a successful future response when CustomsOffice is not found" in {
+      "should throw a NotFoundException for an empty list of customs offices" in {
         val countryId = "AR"
 
         server.stubFor(
-          get(urlEqualTo(url(countryId))).willReturn(
-            aResponse()
-              .withStatus(NO_CONTENT)
-              .withHeader(CONTENT_TYPE, JSON)
-          )
+          get(urlEqualTo(url(countryId)))
+            .willReturn(okJson(emptyResponseJson))
         )
 
-        val expectedResult = Nil
-
-        connector.getCustomsOfficesOfDestinationForCountry(CountryCode(countryId)).futureValue mustBe expectedResult
+        whenReady[Throwable, Assertion](connector.getCustomsOfficesOfDestinationForCountry(CountryCode(countryId)).failed) {
+          _ mustBe a[NotFoundException]
+        }
       }
 
       "must return an exception when an error response is returned" in {
@@ -334,20 +334,17 @@ class ReferenceDataConnectorSpec extends SpecBase with AppWithDefaultMockFixture
         connector.getCustomsOfficesOfExitForCountry(CountryCode(countryId)).futureValue mustBe expectedResult
       }
 
-      "must return a successful future response when CustomsOffice is not found" in {
+      "should throw a NotFoundException for an empty list of customs offices" in {
         val countryId = "AR"
 
         server.stubFor(
-          get(urlEqualTo(url(countryId))).willReturn(
-            aResponse()
-              .withStatus(NO_CONTENT)
-              .withHeader(CONTENT_TYPE, JSON)
-          )
+          get(urlEqualTo(url(countryId)))
+            .willReturn(okJson(emptyResponseJson))
         )
 
-        val expectedResult = Nil
-
-        connector.getCustomsOfficesOfExitForCountry(CountryCode(countryId)).futureValue mustBe expectedResult
+        whenReady[Throwable, Assertion](connector.getCustomsOfficesOfExitForCountry(CountryCode(countryId)).failed) {
+          _ mustBe a[NotFoundException]
+        }
       }
 
       "must return an exception when an error response is returned" in {
@@ -375,20 +372,17 @@ class ReferenceDataConnectorSpec extends SpecBase with AppWithDefaultMockFixture
         connector.getCustomsOfficesOfDepartureForCountry(countryId).futureValue mustBe expectedResult
       }
 
-      "must return a successful future response when CustomsOffice is not found" in {
+      "should throw a NotFoundException for an empty list of customs offices" in {
         val countryId = "AR"
 
         server.stubFor(
-          get(urlEqualTo(url(countryId))).willReturn(
-            aResponse()
-              .withStatus(NO_CONTENT)
-              .withHeader(CONTENT_TYPE, JSON)
-          )
+          get(urlEqualTo(url(countryId)))
+            .willReturn(okJson(emptyResponseJson))
         )
 
-        val expectedResult = Nil
-
-        connector.getCustomsOfficesOfDepartureForCountry(countryId).futureValue mustBe expectedResult
+        whenReady[Throwable, Assertion](connector.getCustomsOfficesOfDepartureForCountry(countryId).failed) {
+          _ mustBe a[NotFoundException]
+        }
       }
 
       "must return an exception when an error response is returned" in {
@@ -555,7 +549,6 @@ class ReferenceDataConnectorSpec extends SpecBase with AppWithDefaultMockFixture
   private def checkErrorResponse(url: String, result: => Future[_]): Assertion = {
     val errorResponses: Gen[Int] = Gen
       .chooseNum(400: Int, 599: Int)
-      .suchThat(_ != 404)
 
     forAll(errorResponses) {
       errorResponse =>
@@ -567,7 +560,7 @@ class ReferenceDataConnectorSpec extends SpecBase with AppWithDefaultMockFixture
             )
         )
 
-        whenReady(result.failed) {
+        whenReady[Throwable, Assertion](result.failed) {
           _ mustBe an[Exception]
         }
     }

--- a/test/controllers/exit/index/OfficeOfExitCountryControllerSpec.scala
+++ b/test/controllers/exit/index/OfficeOfExitCountryControllerSpec.scala
@@ -17,6 +17,7 @@
 package controllers.exit.index
 
 import base.{AppWithDefaultMockFixtures, SpecBase}
+import connectors.ReferenceDataConnector.NoReferenceDataFoundException
 import forms.SelectableFormProvider
 import generators.Generators
 import models.reference.CustomsOffice
@@ -34,7 +35,6 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.CustomsOfficesService
-import uk.gov.hmrc.http.NotFoundException
 import views.html.exit.index.OfficeOfExitCountryView
 
 import scala.concurrent.Future
@@ -182,7 +182,7 @@ class OfficeOfExitCountryControllerSpec extends SpecBase with AppWithDefaultMock
         .thenReturn(Future.successful(countryList))
 
       when(mockCustomsOfficesService.getCustomsOfficesOfExitForCountry(any())(any()))
-        .thenReturn(Future.failed(new NotFoundException("")))
+        .thenReturn(Future.failed(new NoReferenceDataFoundException))
 
       setExistingUserAnswers(baseAnswers)
 

--- a/test/controllers/exit/index/OfficeOfExitCountryControllerSpec.scala
+++ b/test/controllers/exit/index/OfficeOfExitCountryControllerSpec.scala
@@ -34,6 +34,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.CustomsOfficesService
+import uk.gov.hmrc.http.NotFoundException
 import views.html.exit.index.OfficeOfExitCountryView
 
 import scala.concurrent.Future
@@ -181,7 +182,7 @@ class OfficeOfExitCountryControllerSpec extends SpecBase with AppWithDefaultMock
         .thenReturn(Future.successful(countryList))
 
       when(mockCustomsOfficesService.getCustomsOfficesOfExitForCountry(any())(any()))
-        .thenReturn(Future.successful(SelectableList(Nil)))
+        .thenReturn(Future.failed(new NotFoundException("")))
 
       setExistingUserAnswers(baseAnswers)
 

--- a/test/controllers/routing/CountryOfDestinationControllerSpec.scala
+++ b/test/controllers/routing/CountryOfDestinationControllerSpec.scala
@@ -32,6 +32,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.CustomsOfficesService
+import uk.gov.hmrc.http.NotFoundException
 import views.html.routing.CountryOfDestinationView
 
 import scala.concurrent.Future
@@ -152,7 +153,7 @@ class CountryOfDestinationControllerSpec extends SpecBase with AppWithDefaultMoc
       when(mockCountriesService.getDestinationCountries(any())(any()))
         .thenReturn(Future.successful(countryList))
       when(mockCustomsOfficesService.getCustomsOfficesOfDestinationForCountry(any())(any()))
-        .thenReturn(Future.successful(SelectableList(Nil)))
+        .thenReturn(Future.failed(new NotFoundException("")))
 
       setExistingUserAnswers(emptyUserAnswers)
 

--- a/test/controllers/routing/CountryOfDestinationControllerSpec.scala
+++ b/test/controllers/routing/CountryOfDestinationControllerSpec.scala
@@ -17,6 +17,7 @@
 package controllers.routing
 
 import base.{AppWithDefaultMockFixtures, SpecBase}
+import connectors.ReferenceDataConnector.NoReferenceDataFoundException
 import forms.SelectableFormProvider
 import generators.Generators
 import models.reference.CustomsOffice
@@ -32,7 +33,6 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.CustomsOfficesService
-import uk.gov.hmrc.http.NotFoundException
 import views.html.routing.CountryOfDestinationView
 
 import scala.concurrent.Future
@@ -153,7 +153,7 @@ class CountryOfDestinationControllerSpec extends SpecBase with AppWithDefaultMoc
       when(mockCountriesService.getDestinationCountries(any())(any()))
         .thenReturn(Future.successful(countryList))
       when(mockCustomsOfficesService.getCustomsOfficesOfDestinationForCountry(any())(any()))
-        .thenReturn(Future.failed(new NotFoundException("")))
+        .thenReturn(Future.failed(new NoReferenceDataFoundException))
 
       setExistingUserAnswers(emptyUserAnswers)
 

--- a/test/controllers/transit/index/OfficeOfTransitCountryControllerSpec.scala
+++ b/test/controllers/transit/index/OfficeOfTransitCountryControllerSpec.scala
@@ -33,6 +33,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.CustomsOfficesService
+import uk.gov.hmrc.http.NotFoundException
 import views.html.transit.index.OfficeOfTransitCountryView
 
 import scala.concurrent.Future
@@ -177,7 +178,7 @@ class OfficeOfTransitCountryControllerSpec extends SpecBase with AppWithDefaultM
       when(mockCountriesService.getCountries()(any()))
         .thenReturn(Future.successful(countryList))
       when(mockCustomsOfficesService.getCustomsOfficesOfTransitForCountry(any())(any()))
-        .thenReturn(Future.successful(SelectableList(Nil)))
+        .thenReturn(Future.failed(new NotFoundException("")))
 
       setExistingUserAnswers(emptyUserAnswers)
 

--- a/test/controllers/transit/index/OfficeOfTransitCountryControllerSpec.scala
+++ b/test/controllers/transit/index/OfficeOfTransitCountryControllerSpec.scala
@@ -17,6 +17,7 @@
 package controllers.transit.index
 
 import base.{AppWithDefaultMockFixtures, SpecBase}
+import connectors.ReferenceDataConnector.NoReferenceDataFoundException
 import forms.SelectableFormProvider
 import generators.Generators
 import models.reference.CustomsOffice
@@ -33,7 +34,6 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.CustomsOfficesService
-import uk.gov.hmrc.http.NotFoundException
 import views.html.transit.index.OfficeOfTransitCountryView
 
 import scala.concurrent.Future
@@ -178,7 +178,7 @@ class OfficeOfTransitCountryControllerSpec extends SpecBase with AppWithDefaultM
       when(mockCountriesService.getCountries()(any()))
         .thenReturn(Future.successful(countryList))
       when(mockCustomsOfficesService.getCustomsOfficesOfTransitForCountry(any())(any()))
-        .thenReturn(Future.failed(new NotFoundException("")))
+        .thenReturn(Future.failed(new NoReferenceDataFoundException))
 
       setExistingUserAnswers(emptyUserAnswers)
 


### PR DESCRIPTION
Throws an exception if the call to reference data returns an empty list. There are certain scenarios where we intercept this exception and return a bad request to signify that the selection will cause issues on the subsequent page (i.e. the selected country has no customs offices)